### PR TITLE
docs: Phase 4 CDK Integration Analysis

### DIFF
--- a/docs/PHASE2-ESM-ANALYSIS.md
+++ b/docs/PHASE2-ESM-ANALYSIS.md
@@ -1,0 +1,560 @@
+# PHASE 2: ES6/ESM Conversion Analysis
+
+**Date:** 2025-02-08  
+**Repository:** brickhouse-tech/cfn-include  
+**Package:** @znemz/cfn-include@2.1.18
+
+---
+
+## Table of Contents
+1. [Executive Summary](#executive-summary)
+2. [Current CommonJS Patterns](#current-commonjs-patterns)
+3. [Dependency ESM Compatibility](#dependency-esm-compatibility)
+4. [Conversion Challenges](#conversion-challenges)
+5. [File-by-File Conversion Checklist](#file-by-file-conversion-checklist)
+6. [ESM Migration Plan](#esm-migration-plan)
+7. [Testing Strategy](#testing-strategy)
+
+---
+
+## Executive Summary
+
+This analysis covers the conversion of cfn-include from CommonJS to ES6 Modules (ESM). The codebase consists of:
+- **12 source files** (index.js, bin/cli.js, lib/*.js)
+- **7 test files** (t/*.js, t/tests/*.js)
+
+**Key Findings:**
+- ✅ No `__dirname`/`__filename` usage in source files (only in tests)
+- ✅ No dynamic `require()` calls that would complicate ESM
+- ⚠️ The CLI already uses dynamic `import()` for yargs
+- ⚠️ One deprecated dependency (`lib/include/api.js` uses `aws-sdk-proxy` - legacy SDK v2)
+- ✅ All major dependencies have ESM support or can be replaced
+
+---
+
+## Current CommonJS Patterns
+
+### 1. All `require()` Statements
+
+#### `/index.js` (Main Entry Point)
+```javascript
+const url = require('url');                    // Node builtin
+const path = require('path');                  // Node builtin
+const { readFile } = require('fs/promises');   // Node builtin
+const _ = require('lodash');                   // Has ESM
+const { globSync } = require('glob');          // Has ESM
+const Promise = require('bluebird');           // ⚠️ No ESM, needs replacement
+const sortObject = require('@znemz/sort-object'); // Internal package
+const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3'); // Has ESM
+const { addProxyToClient } = require('aws-sdk-v3-proxy'); // Has ESM
+const pathParse = require('path-parse');       // CJS only, needs replacement
+const deepMerge = require('deepmerge');        // Has ESM
+const { isTaggableResource } = require('@znemz/cft-utils/src/resources/taggable'); // Internal
+const request = require('./lib/request');       // Local
+const PromiseExt = require('./lib/promise');    // Local
+const yaml = require('./lib/yaml');             // Local
+const { getParser } = require('./lib/include/query');     // Local
+const parseLocation = require('./lib/parselocation');     // Local
+const replaceEnv = require('./lib/replaceEnv'); // Local
+const { lowerCamelCase, upperCamelCase } = require('./lib/utils');    // Local
+const { isOurExplicitFunction } = require('./lib/schema');            // Local
+const { getAwsPseudoParameters, buildResourceArn } = require('./lib/internals'); // Local
+```
+
+#### `/bin/cli.js`
+```javascript
+const exec = require('child_process').execSync;  // Node builtin
+const path = require('path');                    // Node builtin
+const _ = require('lodash');                     // Has ESM
+const pathParse = require('path-parse');         // CJS only
+const include = require('../index');              // Local
+const yaml = require('../lib/yaml');              // Local
+const Client = require('../lib/cfnclient');       // Local
+const pkg = require('../package.json');           // ⚠️ JSON import
+const replaceEnv = require('../lib/replaceEnv');  // Local
+
+// Already uses dynamic import for ESM packages:
+const { default: yargs } = await import('yargs');
+const { hideBin } = await import('yargs/helpers');
+```
+
+#### `/lib/request.js`
+```javascript
+var url = require('url');    // Node builtin
+var https = require('https'); // Node builtin
+var http = require('http');   // Node builtin
+```
+
+#### `/lib/promise.js`
+```javascript
+const Promise = require('bluebird');  // ⚠️ No ESM
+const _ = require('lodash');          // Has ESM
+```
+
+#### `/lib/include/query.js`
+```javascript
+const { get } = require("lodash");       // Has ESM
+const { search } = require("jmespath");  // Has ESM
+```
+
+#### `/lib/include/api.js` (⚠️ DEPRECATED/UNUSED)
+```javascript
+let AWS = require('aws-sdk-proxy');      // ⚠️ Legacy SDK v2!
+let jmespath = require('jmespath');       // Has ESM
+```
+> **Note:** This file appears unused. It references the deprecated aws-sdk-proxy (v2 SDK). Should be removed or rewritten for v3.
+
+#### `/lib/internals.js`
+```javascript
+// No requires - pure functions only
+```
+
+#### `/lib/schema.js`
+```javascript
+var yaml = require('js-yaml');  // Has ESM
+var _ = require('lodash');       // Has ESM
+```
+
+#### `/lib/utils.js`
+```javascript
+const assert = require('assert').strict;  // Node builtin
+```
+
+#### `/lib/yaml.js`
+```javascript
+const minify = require('jsonminify');  // CJS only
+const yaml = require('js-yaml');        // Has ESM
+const yamlSchema = require('./schema'); // Local
+```
+
+#### `/lib/replaceEnv.js`
+```javascript
+// No requires - pure functions only
+```
+
+#### `/lib/parselocation.js`
+```javascript
+var { isUndefined } = require('lodash');  // Has ESM
+```
+
+#### `/lib/cfnclient.js`
+```javascript
+const { CloudFormationClient, ValidateTemplateCommand } = require('@aws-sdk/client-cloudformation'); // Has ESM
+const { S3Client, PutObjectCommand, DeleteObjectCommand } = require('@aws-sdk/client-s3');          // Has ESM
+const { addProxyToClient } = require('aws-sdk-v3-proxy');  // Has ESM
+const { posix: path } = require('path');   // Node builtin
+const crypto = require('crypto');          // Node builtin
+```
+
+### 2. All `module.exports` Usage
+
+| File | Export Style |
+|------|-------------|
+| `/index.js` | `module.exports = async function (options) { ... }` |
+| `/bin/cli.js` | N/A (CLI entry point, no exports) |
+| `/lib/request.js` | `module.exports = function(location) { ... }` |
+| `/lib/promise.js` | `module.exports = { mapWhatever, mapX }` |
+| `/lib/include/query.js` | `module.exports = { getParser }` |
+| `/lib/include/api.js` | `module.exports = function (args) { ... }` |
+| `/lib/internals.js` | `module.exports = { getAwsPseudoParameters, buildResourceArn }` |
+| `/lib/schema.js` | `module.exports = yaml.DEFAULT_SCHEMA.extend(tags);` + additional exports |
+| `/lib/utils.js` | `module.exports = { lowerCamelCase, upperCamelCase }` |
+| `/lib/yaml.js` | `module.exports = { load, dump }` |
+| `/lib/replaceEnv.js` | `module.exports = replaceEnv;` + `replaceEnv.IsRegExVar = IsRegExVar;` |
+| `/lib/parselocation.js` | `module.exports = function parseLocation(location) { ... }` |
+| `/lib/cfnclient.js` | `module.exports = Client;` |
+
+### 3. Dynamic Requires Analysis
+
+**Good news:** There are **no problematic dynamic requires** in the source code.
+
+The only dynamic-looking pattern is in the test files:
+```javascript
+// t/include.js - This is a computed test file path
+require(`./tests/${file}`)
+
+// t/cli.js - Same pattern for test loading
+require(`./tests/${file}.json`)
+```
+
+These test patterns can be converted to dynamic `import()` easily.
+
+### 4. Circular Dependency Analysis
+
+**Dependency Graph:**
+```
+index.js
+├── lib/request.js          (no deps on lib/)
+├── lib/promise.js          (no deps on lib/)
+├── lib/yaml.js             (depends on lib/schema.js)
+│   └── lib/schema.js       (no deps on lib/)
+├── lib/include/query.js    (no deps on lib/)
+├── lib/parselocation.js    (no deps on lib/)
+├── lib/replaceEnv.js       (no deps on lib/)
+├── lib/utils.js            (no deps on lib/)
+├── lib/schema.js           (no deps on lib/)
+└── lib/internals.js        (no deps on lib/)
+
+bin/cli.js
+├── index.js (circular OK - no issue at runtime)
+├── lib/yaml.js
+├── lib/cfnclient.js
+│   └── (no deps on lib/)
+└── lib/replaceEnv.js
+```
+
+**Result: No circular dependencies exist.**
+
+---
+
+## Dependency ESM Compatibility
+
+### NPM Dependencies Analysis
+
+| Package | Version | ESM Support | Recommendation |
+|---------|---------|-------------|----------------|
+| `lodash` | ^4.17.21 | ✅ Via `lodash-es` | Replace with `lodash-es` or cherry-pick imports |
+| `bluebird` | ^3.7.2 | ❌ No ESM | **Replace with native Promise** |
+| `js-yaml` | ^4.1.1 | ✅ Has ESM | Direct import works |
+| `glob` | ^13.0.0 | ✅ Pure ESM | Already compatible |
+| `deepmerge` | ^4.2.2 | ✅ Has ESM | Direct import works |
+| `jmespath` | ^0.16.0 | ✅ Has ESM | Direct import works |
+| `jsonminify` | ^0.4.1 | ❌ CJS only | Replace with `minify-json` or inline |
+| `path-parse` | ~1.0.7 | ❌ CJS only | **Replace with Node `path.parse()`** |
+| `@aws-sdk/client-s3` | ^3.637.0 | ✅ Full ESM | Direct import works |
+| `@aws-sdk/client-cloudformation` | ^3.637.0 | ✅ Full ESM | Direct import works |
+| `aws-sdk-v3-proxy` | 2.2.0 | ✅ Has ESM | Direct import works |
+| `@znemz/sort-object` | ^3.0.4 | ⚠️ Check | Internal package, convert as needed |
+| `@znemz/cft-utils` | 0.1.33 | ⚠️ Check | Internal package, convert as needed |
+| `yargs` | ~18.0.0 | ✅ Pure ESM | Already imported dynamically |
+
+### Replacements Needed
+
+#### 1. `bluebird` → Native Promise + Custom Helpers
+Bluebird is used for:
+- `Promise.props()` - Map object values to promises
+- `Promise.map()` - Concurrent array mapping
+- `Promise.try()` - Safe promise start
+
+**Native replacements:**
+```javascript
+// Promise.props equivalent
+async function promiseProps(obj) {
+  const entries = Object.entries(obj);
+  const values = await Promise.all(entries.map(([, v]) => v));
+  return Object.fromEntries(entries.map(([k], i) => [k, values[i]]));
+}
+
+// Promise.map equivalent (with concurrency)
+async function promiseMap(arr, fn, { concurrency = Infinity } = {}) {
+  if (concurrency === Infinity) return Promise.all(arr.map(fn));
+  const results = [];
+  for (let i = 0; i < arr.length; i += concurrency) {
+    const chunk = arr.slice(i, i + concurrency);
+    results.push(...await Promise.all(chunk.map((item, j) => fn(item, i + j))));
+  }
+  return results;
+}
+
+// Promise.try equivalent
+const promiseTry = (fn) => new Promise((resolve) => resolve(fn()));
+```
+
+#### 2. `path-parse` → Native `path.parse()`
+```javascript
+// Before
+const pathParse = require('path-parse');
+const parsed = pathParse('/foo/bar.json');
+
+// After
+import path from 'node:path';
+const parsed = path.parse('/foo/bar.json');
+```
+
+#### 3. `jsonminify` → Inline implementation or alternative
+```javascript
+// Simple JSON minify (remove comments and whitespace)
+function jsonMinify(json) {
+  return JSON.stringify(JSON.parse(json));
+}
+// Note: This loses comment support. May need more complex solution if comments are used.
+```
+
+---
+
+## Conversion Challenges
+
+### 1. `__dirname` / `__filename` Replacements
+
+**Source files:** ✅ **No usage found!**
+
+**Test files only:**
+```javascript
+// t/include.js line 65
+url: `file://${__dirname}/template.json`
+```
+
+**ESM Replacement:**
+```javascript
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+```
+
+### 2. JSON Imports
+
+The CLI imports `package.json`:
+```javascript
+const pkg = require('../package.json');
+```
+
+**ESM options:**
+```javascript
+// Option 1: Import assertion (Node 18+, experimental)
+import pkg from '../package.json' with { type: 'json' };
+
+// Option 2: Read and parse (safest)
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+const pkg = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+);
+
+// Option 3: createRequire (hybrid approach)
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+```
+
+### 3. Top-Level Await Opportunities
+
+The CLI already uses top-level await (wrapped in IIFE). Can simplify:
+```javascript
+// Current (wrapped IIFE)
+(async () => {
+  const { default: yargs } = await import('yargs');
+  // ...
+})();
+
+// ESM with top-level await
+const { default: yargs } = await import('yargs');
+// ... rest of code
+```
+
+### 4. Dynamic Imports in Tests
+
+```javascript
+// Current
+const testFile = require(`./tests/${file}`);
+
+// ESM
+const testFile = await import(`./tests/${file}`);
+```
+
+### 5. Default Export Pattern Change
+
+```javascript
+// Current (CommonJS)
+module.exports = async function (options) { ... }
+
+// ESM equivalent
+export default async function (options) { ... }
+```
+
+---
+
+## File-by-File Conversion Checklist
+
+### Conversion Order (Leaf Dependencies First)
+
+| Order | File | Complexity | Dependencies | Notes |
+|-------|------|------------|--------------|-------|
+| 1 | `/lib/internals.js` | 🟢 Easy | None | Pure functions, no requires |
+| 2 | `/lib/replaceEnv.js` | 🟢 Easy | None | Pure functions, no requires |
+| 3 | `/lib/utils.js` | 🟢 Easy | `assert` | Only Node builtin |
+| 4 | `/lib/parselocation.js` | 🟢 Easy | `lodash` | Single lodash import |
+| 5 | `/lib/request.js` | 🟢 Easy | `url`, `http`, `https` | All Node builtins |
+| 6 | `/lib/schema.js` | 🟡 Medium | `js-yaml`, `lodash` | Creates YAML schema |
+| 7 | `/lib/yaml.js` | 🟡 Medium | `jsonminify`, `js-yaml`, local | jsonminify needs replacement |
+| 8 | `/lib/include/query.js` | 🟢 Easy | `lodash`, `jmespath` | Small file |
+| 9 | `/lib/promise.js` | 🟡 Medium | `bluebird`, `lodash` | **Bluebird replacement needed** |
+| 10 | `/lib/cfnclient.js` | 🟡 Medium | AWS SDK, `path`, `crypto` | Class export |
+| 11 | `/lib/include/api.js` | 🔴 Complex | `aws-sdk-proxy` (v2!) | **Consider removing/rewriting** |
+| 12 | `/index.js` | 🔴 Complex | Many deps | Main module, many imports |
+| 13 | `/bin/cli.js` | 🟡 Medium | Local modules, yargs | CLI entry point |
+
+### Test File Conversion (After Source)
+
+| File | Notes |
+|------|-------|
+| `/t/include.js` | Uses `__dirname`, dynamic require |
+| `/t/cli.js` | Uses child_process, dynamic require |
+| `/t/replaceEnv.js` | Simple, one assertion |
+| `/t/tests/extendEnv.js` | Uses lodash |
+| `/t/tests/yaml.js` | Uses assert |
+| `/t/tests/*.js` | Data files, minimal changes |
+
+---
+
+## ESM Migration Plan
+
+### Phase 2A: Package.json Configuration
+
+```json
+{
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./lib/*": {
+      "import": "./lib/*.js",
+      "require": "./dist/lib/*.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./index.js",
+  "engines": {
+    "node": ">=20.19"
+  }
+}
+```
+
+### Phase 2B: Replace Dependencies
+
+1. **Remove `bluebird`** - Replace with native Promise helpers
+2. **Remove `path-parse`** - Use Node's built-in `path.parse()`
+3. **Replace `jsonminify`** - Inline or use ESM alternative
+4. **Update `lodash`** - Use `lodash-es` or individual imports
+5. **Remove `lib/include/api.js`** - Unused legacy code
+
+### Phase 2C: Convert Files (In Order)
+
+1. **Add ESM polyfills file** (`/lib/esm-compat.js`):
+   ```javascript
+   // Polyfills for CJS patterns
+   import { fileURLToPath } from 'node:url';
+   import { dirname } from 'node:path';
+   
+   export const getDirname = (importMetaUrl) => 
+     dirname(fileURLToPath(importMetaUrl));
+   
+   export async function promiseProps(obj) { /* ... */ }
+   export async function promiseMap(arr, fn) { /* ... */ }
+   ```
+
+2. **Convert leaf modules** (internals, utils, replaceEnv, parselocation, request)
+3. **Convert intermediate modules** (schema, yaml, query, promise)
+4. **Convert main module** (index.js)
+5. **Convert CLI** (bin/cli.js)
+6. **Convert tests**
+
+### Phase 2D: Dual Package Support (Optional)
+
+For backwards compatibility, build CJS versions:
+
+```bash
+# Using esbuild for CJS transpilation
+npx esbuild index.js --bundle --platform=node --format=cjs --outfile=dist/index.cjs
+npx esbuild lib/*.js --platform=node --format=cjs --outdir=dist/lib
+```
+
+### Phase 2E: Bun Compatibility
+
+**Status:** Bun is not installed on this system.
+
+**Bun Considerations:**
+- ✅ Bun supports ESM natively
+- ✅ Bun has built-in `Bun.file()` for file reading
+- ⚠️ Some Node APIs may differ slightly
+- ✅ Test with `bun test` after conversion
+
+**Recommendation:** After ESM conversion, add Bun to CI:
+```yaml
+# .github/workflows/test.yml
+jobs:
+  test-bun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun test
+```
+
+---
+
+## Testing Strategy
+
+### Between Each Conversion Step
+
+1. **Run existing tests** after each file conversion
+   ```bash
+   npm test
+   ```
+
+2. **Verify CLI works**
+   ```bash
+   echo '{"Fn::Include": "t/fixtures/simple.json"}' | node bin/cli.js
+   ```
+
+3. **Check for import errors**
+   ```bash
+   node --experimental-vm-modules -e "import('./index.js').then(m => console.log('OK', typeof m.default))"
+   ```
+
+### Full Test Strategy
+
+1. **Unit tests** - Convert Mocha tests to ESM
+2. **CLI tests** - Keep child_process spawning
+3. **Integration tests** - Test with real templates
+4. **Cross-runtime** - Test on Node 20, 22, and Bun
+
+### ESM Test Configuration
+
+Update `mocha` config for ESM:
+```javascript
+// mocha.config.mjs
+export default {
+  timeout: 20000,
+  bail: true,
+  spec: ['t/**/*.js'],
+  // Enable experimental ESM loader
+  'node-option': ['experimental-vm-modules']
+};
+```
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Breaking changes | Medium | High | Dual CJS/ESM package |
+| Bluebird removal breaks async | Low | High | Comprehensive test coverage |
+| Test failures | Medium | Medium | Convert tests incrementally |
+| Dependency ESM issues | Low | Medium | Pin versions, test thoroughly |
+
+---
+
+## Conclusion
+
+The cfn-include codebase is **well-suited for ESM conversion**:
+- No circular dependencies
+- No problematic dynamic requires
+- No `__dirname`/`__filename` in source (only tests)
+- Most dependencies have ESM support
+- Clean separation of concerns
+
+**Estimated effort:** 2-3 days for full conversion with testing.
+
+**Recommended approach:**
+1. Start with leaf dependencies (lib/*.js)
+2. Convert main index.js
+3. Convert CLI
+4. Convert tests
+5. Add dual package support if needed
+6. Test on Node 20/22 and Bun

--- a/docs/PHASE4-CDK-INTEGRATION-ANALYSIS.md
+++ b/docs/PHASE4-CDK-INTEGRATION-ANALYSIS.md
@@ -1,0 +1,635 @@
+# Phase 4: AWS CDK Import/Eject Functionality Analysis
+
+**Date:** February 8, 2026  
+**Author:** TARS (nmccready-tars)  
+**Status:** Research & Design Complete
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [AWS CDK CfnInclude Module Research](#2-aws-cdk-cfninclude-module-research)
+3. [Existing Tools Analysis](#3-existing-tools-analysis)
+4. [EJECT Functionality Design (cfn-include → CDK)](#4-eject-functionality-design-cfn-include--cdk)
+5. [IMPORT Functionality Design (CDK → cfn-include)](#5-import-functionality-design-cdk--cfn-include)
+6. [CLI Design](#6-cli-design)
+7. [Challenges and Limitations](#7-challenges-and-limitations)
+8. [Implementation Roadmap](#8-implementation-roadmap)
+9. [Appendix: cfn-include Function Mapping](#appendix-cfn-include-function-mapping)
+
+---
+
+## 1. Executive Summary
+
+This document analyzes the feasibility and design of bidirectional integration between `cfn-include` (a CloudFormation template preprocessor) and AWS CDK (Cloud Development Kit). The goal is to enable:
+
+1. **EJECT** - Convert cfn-include templates to AWS CDK TypeScript/Python code
+2. **IMPORT** - Convert CDK-synthesized CloudFormation templates back to optimized cfn-include templates
+
+### Key Findings
+
+- **EJECT is feasible** but requires a two-phase approach: first resolve all custom `Fn::*` functions, then convert to CDK
+- **IMPORT has limited utility** - CDK templates are already optimized for CDK workflows; reverse engineering patterns is complex
+- **Existing tools exist** - `cdk-from-cfn` handles the CloudFormation → CDK conversion well
+- **Fn::Eval is non-portable** - Arbitrary JavaScript cannot be safely converted to CDK
+
+### Recommended Approach
+
+Implement EJECT as a wrapper around existing tools (`cdk-from-cfn`) with a pre-processing step that resolves cfn-include's custom functions. IMPORT should focus on pattern detection for migration assistance rather than full conversion.
+
+---
+
+## 2. AWS CDK CfnInclude Module Research
+
+### 2.1 What is @aws-cdk/cloudformation-include?
+
+The `cloudformation-include` module (now `aws-cdk-lib/cloudformation-include`) allows importing existing CloudFormation templates into CDK applications. It provides:
+
+```typescript
+import * as cfn_inc from 'aws-cdk-lib/cloudformation-include';
+
+const cfnTemplate = new cfn_inc.CfnInclude(this, 'Template', {
+  templateFile: 'my-template.json',
+});
+```
+
+### 2.2 Key Capabilities
+
+| Feature | Description |
+|---------|-------------|
+| **Template Import** | Import JSON/YAML CloudFormation templates |
+| **Resource Access** | Get L1 constructs via `getResource('LogicalId')` |
+| **L1 → L2 Conversion** | Convert with `fromCfn*()` methods (e.g., `Key.fromCfnKey()`) |
+| **Parameter Replacement** | Replace parameters with build-time values |
+| **Nested Stacks** | Support for `AWS::CloudFormation::Stack` resources |
+| **Preserve Logical IDs** | Option to keep original IDs or rename with CDK algorithm |
+
+### 2.3 Construct Levels in CDK
+
+| Level | Description | Example |
+|-------|-------------|---------|
+| **L1 (CfnXxx)** | 1:1 mapping to CloudFormation resources | `CfnBucket` |
+| **L2 (High-Level)** | Abstractions with sensible defaults | `Bucket` |
+| **L3 (Patterns)** | Multi-resource patterns | `ApplicationLoadBalancedFargateService` |
+
+**cfn-include templates produce L1 constructs when imported via CfnInclude**, since they're raw CloudFormation.
+
+### 2.4 Converting L1 to L2
+
+Two methods:
+
+**Method 1: `fromCfn*()` methods (Preferred)**
+```typescript
+const cfnKey = cfnTemplate.getResource('Key') as kms.CfnKey;
+const key = kms.Key.fromCfnKey(cfnKey); // Mutable L2
+```
+
+**Method 2: `fromXxxArn/Name()` methods (Fallback)**
+```typescript
+const cfnBucket = cfnTemplate.getResource('Bucket') as s3.CfnBucket;
+const bucket = s3.Bucket.fromBucketName(this, 'L2Bucket', cfnBucket.ref); // Immutable
+```
+
+### 2.5 Limitations of CfnInclude
+
+- Does not execute CloudFormation transforms
+- Cannot handle cycles between resources (unless `allowCyclicalReferences: true`)
+- Resources using complex `Fn::If` may not convert to L2
+- Custom resources return as generic `CfnResource`
+
+---
+
+## 3. Existing Tools Analysis
+
+### 3.1 cdk-from-cfn
+
+**Repository:** `cdklabs/cdk-from-cfn`  
+**Type:** Rust CLI with WASM bindings (npm package available)
+
+**Features:**
+- Converts CloudFormation JSON/YAML to CDK code
+- Supports: TypeScript, Python, Java, Go, C#
+- Generates either `Stack` or `Construct` classes
+- Handles most intrinsic functions
+
+**Supported Intrinsic Functions:**
+- ✅ `Fn::FindInMap`, `Fn::Join`, `Fn::Sub`, `Ref`
+- ✅ `Fn::And`, `Fn::Equals`, `Fn::If`, `Fn::Not`, `Fn::Or`
+- ✅ `Fn::GetAtt`, `Fn::Base64`, `Fn::ImportValue`, `Fn::Select`
+- ✅ `Fn::GetAZs`, `Fn::Cidr`
+- ❌ SSM/SecretsManager dynamic references
+- ❌ Create policies
+
+**Usage:**
+```bash
+# CLI
+cdk-from-cfn template.json output.ts --language typescript --stack-name MyStack
+
+# Node.js
+import * as cdk_from_cfn from 'cdk-from-cfn';
+const cdkCode = cdk_from_cfn.transmute(template, 'typescript', 'MyStack');
+```
+
+### 3.2 AWS CloudFormation Registry
+
+The CDK uses CloudFormation schema definitions from the registry to generate L1 constructs. This is why `cdk-from-cfn` can accurately map resources.
+
+### 3.3 Other Tools
+
+| Tool | Description | Status |
+|------|-------------|--------|
+| **former2** | Generates IaC from existing AWS resources | Alternative approach |
+| **AWS CDK Migrate** | Official tool for importing existing stacks | Stack-focused, not template-focused |
+
+---
+
+## 4. EJECT Functionality Design (cfn-include → CDK)
+
+### 4.1 Overview
+
+Convert a cfn-include template (with custom `Fn::*` functions) to AWS CDK code.
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  cfn-include    │────▶│  Standard CFN   │────▶│   CDK Code      │
+│  Template       │     │  Template       │     │  (TS/Python)    │
+│  (Fn::Include,  │     │  (Resolved)     │     │                 │
+│   Fn::Map, etc) │     │                 │     │                 │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+      Phase 1                Phase 2                Phase 3
+   (cfn-include)         (cdk-from-cfn)        (Code Generation)
+```
+
+### 4.2 Phase 1: Resolve cfn-include Functions
+
+Use the existing `cfn-include` CLI to resolve all custom functions:
+
+```bash
+cfn-include input.yml --enable env,eval > resolved.json
+```
+
+This handles:
+- `Fn::Include` → File contents inlined
+- `Fn::Map` → Array expanded
+- `Fn::Flatten` → Arrays flattened
+- `Fn::Merge` → Objects merged
+- `Fn::RefNow` → References resolved
+- etc.
+
+### 4.3 Phase 2: Convert to CDK
+
+Pass the resolved CloudFormation template to `cdk-from-cfn`:
+
+```typescript
+import * as cdk_from_cfn from 'cdk-from-cfn';
+import * as cfnInclude from '@znemz/cfn-include';
+
+async function eject(templatePath: string, language: string) {
+  // Phase 1: Resolve cfn-include functions
+  const resolved = await cfnInclude({
+    url: `file://${templatePath}`,
+    doEnv: true,
+    doEval: true,
+  });
+  
+  // Phase 2: Convert to CDK
+  const cdkCode = cdk_from_cfn.transmute(
+    JSON.stringify(resolved),
+    language,
+    'GeneratedStack'
+  );
+  
+  return cdkCode;
+}
+```
+
+### 4.4 Phase 3: Output Structure
+
+Generate a complete CDK application structure:
+
+```
+output/
+├── package.json
+├── tsconfig.json
+├── cdk.json
+├── lib/
+│   └── generated-stack.ts    # Generated CDK code
+├── bin/
+│   └── app.ts                # CDK app entry point
+└── README.md                 # Migration notes
+```
+
+### 4.5 Preserving Intent with Comments
+
+Since cfn-include functions carry semantic meaning that's lost in resolution, we should:
+
+1. **Parse original template** to detect cfn-include function usage
+2. **Generate comments** in output explaining original patterns
+
+```typescript
+// Originally: Fn::Map over [80, 443] with template for each port
+const securityGroupIngress80 = new ec2.CfnSecurityGroupIngress(this, 'Ingress80', {
+  // ...
+});
+const securityGroupIngress443 = new ec2.CfnSecurityGroupIngress(this, 'Ingress443', {
+  // ...
+});
+```
+
+### 4.6 Handling Special Cases
+
+#### Fn::Eval (JavaScript Evaluation)
+```yaml
+# NOT CONVERTIBLE - Contains arbitrary JS
+Fn::Eval:
+  state: [1, 2, 3]
+  script: "state.map(v => v * 2);"
+```
+**Strategy:** Warn user, output as comment with manual intervention required.
+
+#### Fn::Include with dynamic paths
+```yaml
+# Dynamic path based on environment
+Fn::Include: "${ENVIRONMENT}/config.yml"
+```
+**Strategy:** Resolve at eject time with specific environment, document the source.
+
+#### Fn::IfEval (Conditional JS)
+```yaml
+Fn::IfEval:
+  evalCond: "('${ENV}' === 'prod')"
+  truthy: { ... }
+  falsy: { ... }
+```
+**Strategy:** Evaluate at eject time, document the condition that was used.
+
+---
+
+## 5. IMPORT Functionality Design (CDK → cfn-include)
+
+### 5.1 Overview
+
+Convert a CDK-synthesized CloudFormation template back to an optimized cfn-include template.
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  CDK Stack      │────▶│  cdk synth      │────▶│  cfn-include    │
+│  (TypeScript)   │     │  output.json    │     │  optimized.yml  │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                              │
+                              ▼
+                        Pattern Detection
+                        - Repeated resources
+                        - Similar structures
+                        - Extractable modules
+```
+
+### 5.2 Pattern Detection Algorithms
+
+#### 5.2.1 Repeated Resource Pattern → Fn::Map
+
+Detect resources with similar structure that differ only in specific values:
+
+```json
+// Input (synthesized CFN)
+{
+  "SubnetA": { "Type": "AWS::EC2::Subnet", "Properties": { "AvailabilityZone": "us-east-1a" } },
+  "SubnetB": { "Type": "AWS::EC2::Subnet", "Properties": { "AvailabilityZone": "us-east-1b" } },
+  "SubnetC": { "Type": "AWS::EC2::Subnet", "Properties": { "AvailabilityZone": "us-east-1c" } }
+}
+```
+
+```yaml
+# Output (cfn-include)
+Fn::Merge:
+  Fn::Map:
+    - [a, b, c]
+    - AZ
+    - Subnet${AZ}:
+        Type: AWS::EC2::Subnet
+        Properties:
+          AvailabilityZone: !Sub us-east-1${AZ}
+```
+
+**Algorithm:**
+1. Group resources by Type
+2. Compare property structures (ignoring values)
+3. Identify varying fields
+4. Check if variations follow a pattern (sequential, from list, etc.)
+5. Generate `Fn::Map` if pattern detected
+
+#### 5.2.2 Similar Structure Detection → Fn::Include
+
+Identify resource blocks that could be extracted to reusable includes:
+
+```json
+// Input: Multiple Lambda functions with similar config
+{
+  "Function1": { "Type": "AWS::Lambda::Function", "Properties": { "Runtime": "nodejs18.x", "Handler": "index.handler", "MemorySize": 256 } },
+  "Function2": { "Type": "AWS::Lambda::Function", "Properties": { "Runtime": "nodejs18.x", "Handler": "index.handler", "MemorySize": 256 } }
+}
+```
+
+```yaml
+# Output: Extracted include
+# includes/lambda-defaults.yml
+Type: AWS::Lambda::Function
+Properties:
+  Runtime: nodejs18.x
+  Handler: index.handler
+  MemorySize: 256
+
+# main.yml
+Function1:
+  Fn::DeepMerge:
+    - Fn::Include: includes/lambda-defaults.yml
+    - Properties:
+        FunctionName: function-1
+Function2:
+  Fn::DeepMerge:
+    - Fn::Include: includes/lambda-defaults.yml
+    - Properties:
+        FunctionName: function-2
+```
+
+### 5.3 Optimization Strategies
+
+| Strategy | Description | Trigger |
+|----------|-------------|---------|
+| **Fn::Map extraction** | Convert repeated resources to map | 3+ similar resources |
+| **Fn::Include extraction** | Extract common patterns to files | Repeated structures |
+| **Fn::Merge usage** | Combine base + overrides | Inheritance patterns |
+| **Fn::Sequence generation** | Detect sequential patterns | A, B, C or 1, 2, 3 patterns |
+
+### 5.4 Limitations of IMPORT
+
+1. **Loss of L2 abstraction** - CDK synthesizes to L1, can't recover L2 intent
+2. **CDK metadata** - Contains CDK-specific constructs that don't reverse well
+3. **Token resolution** - CDK tokens are resolved, original references lost
+4. **Code generation impossible** - Can't regenerate original TypeScript/Python
+
+### 5.5 Recommended Use Cases for IMPORT
+
+- **Migration assistance** - Help identify patterns when migrating away from CDK
+- **Template optimization** - Reduce template size by extracting patterns
+- **Documentation** - Generate simplified cfn-include views of complex CDK stacks
+
+---
+
+## 6. CLI Design
+
+### 6.1 EJECT Command
+
+```bash
+cfn-include eject <template> [options]
+
+Arguments:
+  template                 Path to cfn-include template (YAML/JSON)
+
+Options:
+  -o, --output <dir>       Output directory for CDK app (default: ./cdk-app)
+  -l, --language <lang>    Output language: typescript, python, java, go, csharp
+                           (default: typescript)
+  -n, --stack-name <name>  Name for generated stack class (default: GeneratedStack)
+  --as <type>              Output type: stack, construct (default: stack)
+  --enable <opts>          Enable cfn-include options: env, eval
+  -i, --inject <json>      JSON string for template injection
+  --preserve-comments      Add comments documenting original cfn-include patterns
+  --dry-run                Show what would be generated without writing files
+  -v, --verbose            Verbose output
+
+Examples:
+  cfn-include eject infra.yml -o ./my-cdk-app -l typescript
+  cfn-include eject template.yml --enable env --inject '{"ENV":"prod"}'
+```
+
+### 6.2 IMPORT Command
+
+```bash
+cfn-include import <template> [options]
+
+Arguments:
+  template                 Path to CloudFormation template (from cdk synth)
+
+Options:
+  -o, --output <path>      Output file path (default: stdout)
+  --optimize               Enable pattern detection and optimization
+  --extract-includes       Extract repeated patterns to include files
+  --include-dir <dir>      Directory for extracted includes (default: ./includes)
+  --min-repeat <n>         Minimum repetitions to trigger extraction (default: 3)
+  --format <fmt>           Output format: yaml, json (default: yaml)
+  --analyze-only           Show detected patterns without generating output
+  -v, --verbose            Verbose output
+
+Examples:
+  cfn-include import cdk.out/MyStack.template.json -o optimized.yml --optimize
+  cfn-include import template.json --analyze-only
+```
+
+### 6.3 Integration with Existing CLI
+
+Add to `bin/cli.js`:
+
+```javascript
+const opts = yargs(hideBin(process.argv))
+  .command('$0 [path] [options]', pkg.description, /* ... existing ... */)
+  .command('eject <template>', 'Convert cfn-include template to CDK code', (y) =>
+    y.positional('template', { desc: 'Path to cfn-include template' })
+     .option('output', { alias: 'o', desc: 'Output directory', default: './cdk-app' })
+     .option('language', { alias: 'l', desc: 'Output language', default: 'typescript' })
+     // ... more options
+  )
+  .command('import <template>', 'Import CloudFormation template to cfn-include', (y) =>
+    y.positional('template', { desc: 'Path to CloudFormation template' })
+     .option('output', { alias: 'o', desc: 'Output file path' })
+     .option('optimize', { desc: 'Enable pattern optimization', boolean: true })
+     // ... more options
+  )
+  .parse();
+```
+
+---
+
+## 7. Challenges and Limitations
+
+### 7.1 Non-Convertible Features
+
+| Feature | Issue | Mitigation |
+|---------|-------|------------|
+| `Fn::Eval` | Arbitrary JavaScript execution | Warn user, output as comment |
+| `Fn::IfEval` | Conditional JavaScript | Evaluate at eject time, document |
+| Dynamic `Fn::Include` | Runtime path resolution | Resolve with current env, document |
+| AWS API calls (`type: api`) | Runtime AWS calls | Cache result, document source |
+| Globs (`Fn::Include: *.yml`) | Filesystem dependent | Expand at eject time |
+
+### 7.2 CDK vs cfn-include Paradigm Differences
+
+| Aspect | cfn-include | CDK |
+|--------|-------------|-----|
+| **Evaluation time** | Build time (before deployment) | Synth time (code execution) |
+| **Abstraction** | Template preprocessing | Object-oriented constructs |
+| **Type safety** | None (YAML/JSON) | Full (TypeScript/Python) |
+| **Conditionals** | Fn::If (CloudFormation) + Fn::IfEval | Native language conditionals |
+| **Loops** | Fn::Map (template-based) | Native language loops |
+| **Reuse** | File includes | Classes and composition |
+
+### 7.3 L2 Construct Detection
+
+When importing CDK templates, we cannot reliably detect which L2 constructs were used:
+
+```typescript
+// Original CDK code
+new s3.Bucket(this, 'Bucket', {
+  versioned: true,
+  encryption: BucketEncryption.S3_MANAGED,
+});
+```
+
+```json
+// Synthesized CloudFormation - L2 information lost
+{
+  "Bucket": {
+    "Type": "AWS::S3::Bucket",
+    "Properties": {
+      "VersioningConfiguration": { "Status": "Enabled" },
+      "BucketEncryption": {
+        "ServerSideEncryptionConfiguration": [
+          { "ServerSideEncryptionByDefault": { "SSEAlgorithm": "AES256" } }
+        ]
+      }
+    }
+  }
+}
+```
+
+### 7.4 CDK Metadata and Constructs
+
+CDK adds metadata that's not useful in cfn-include:
+
+```json
+{
+  "Metadata": {
+    "aws:cdk:path": "MyStack/Bucket/Resource"
+  },
+  "Rules": {
+    "CheckBootstrapVersion": { /* CDK bootstrap check */ }
+  }
+}
+```
+
+**Strategy:** Strip CDK-specific metadata during import.
+
+---
+
+## 8. Implementation Roadmap
+
+### Phase 4.1: EJECT MVP (4-6 weeks)
+
+1. **Week 1-2:** Integration with `cdk-from-cfn`
+   - Add as optional dependency
+   - Wrapper function for resolution + conversion
+   - Basic CLI command
+
+2. **Week 3-4:** Output generation
+   - CDK app scaffolding
+   - Package.json generation
+   - TypeScript configuration
+
+3. **Week 5-6:** Documentation and testing
+   - Comment generation for original patterns
+   - Comprehensive test suite
+   - User documentation
+
+### Phase 4.2: IMPORT MVP (6-8 weeks)
+
+1. **Week 1-2:** Pattern detection infrastructure
+   - Resource similarity scoring
+   - Structure comparison algorithms
+
+2. **Week 3-4:** Fn::Map extraction
+   - Repeated resource detection
+   - Variable extraction
+
+3. **Week 5-6:** Fn::Include extraction
+   - Common structure detection
+   - Include file generation
+
+4. **Week 7-8:** Optimization and testing
+   - Fine-tuning detection thresholds
+   - Comprehensive test suite
+
+### Phase 4.3: Advanced Features (Future)
+
+- Python output support for eject
+- Interactive pattern selection for import
+- IDE plugins for migration assistance
+- CI/CD integration helpers
+
+---
+
+## Appendix: cfn-include Function Mapping
+
+### Custom Functions (cfn-include specific)
+
+| Function | Description | CDK Equivalent |
+|----------|-------------|----------------|
+| `Fn::Include` | Include external files | N/A (resolved at preprocessing) |
+| `Fn::Map` | Transform arrays | Native loops |
+| `Fn::Flatten` | Flatten arrays | `Array.flat()` |
+| `Fn::FlattenDeep` | Deep flatten | `Array.flat(Infinity)` |
+| `Fn::Merge` | Merge objects | Object spread / `Object.assign` |
+| `Fn::DeepMerge` | Deep merge objects | Deep merge utility |
+| `Fn::Length` | Array length | `Array.length` |
+| `Fn::Uniq` | Unique values | `[...new Set(arr)]` |
+| `Fn::Compact` | Remove falsy | `Array.filter(Boolean)` |
+| `Fn::Concat` | Concatenate arrays | `Array.concat()` |
+| `Fn::Sort` | Sort array | `Array.sort()` |
+| `Fn::SortBy` | Sort by property | `_.sortBy()` |
+| `Fn::Without` | Remove values | `Array.filter()` |
+| `Fn::Omit` | Omit object keys | Object destructuring |
+| `Fn::OmitEmpty` | Remove empty values | Filter utility |
+| `Fn::ObjectKeys` | Object keys | `Object.keys()` |
+| `Fn::ObjectValues` | Object values | `Object.values()` |
+| `Fn::Stringify` | JSON stringify | `JSON.stringify()` |
+| `Fn::StringSplit` | Split string | `String.split()` |
+| `Fn::Sequence` | Generate sequence | `Array.from({length})` |
+| `Fn::GetEnv` | Environment variable | `process.env` |
+| `Fn::Eval` | JavaScript eval | **Not convertible** |
+| `Fn::IfEval` | Conditional eval | **Not convertible** |
+| `Fn::JoinNow` | Immediate join | `Array.join()` |
+| `Fn::SubNow` | Immediate substitution | Template literals |
+| `Fn::RefNow` | Immediate reference | Variable reference |
+| `Fn::ApplyTags` | Apply tags to resources | Tagging construct |
+| `Fn::Outputs` | Generate outputs | CDK CfnOutput |
+| `Fn::Filenames` | List filenames | `fs.readdirSync()` |
+| `Fn::UpperCamelCase` | Case conversion | String utility |
+| `Fn::LowerCamelCase` | Case conversion | String utility |
+
+### Standard CloudFormation Functions (Preserved)
+
+| Function | CDK Equivalent |
+|----------|----------------|
+| `Ref` | `resource.ref` or `Fn.ref()` |
+| `Fn::GetAtt` | `resource.getAtt()` |
+| `Fn::Join` | `Fn.join()` |
+| `Fn::Sub` | `Fn.sub()` |
+| `Fn::Select` | `Fn.select()` |
+| `Fn::Split` | `Fn.split()` |
+| `Fn::If` | `Fn.conditionIf()` |
+| `Fn::And` | `Fn.conditionAnd()` |
+| `Fn::Or` | `Fn.conditionOr()` |
+| `Fn::Not` | `Fn.conditionNot()` |
+| `Fn::Equals` | `Fn.conditionEquals()` |
+| `Fn::FindInMap` | `Fn.findInMap()` |
+| `Fn::Base64` | `Fn.base64()` |
+| `Fn::Cidr` | `Fn.cidr()` |
+| `Fn::GetAZs` | `Fn.getAzs()` |
+| `Fn::ImportValue` | `Fn.importValue()` |
+
+---
+
+## References
+
+1. [AWS CDK cloudformation-include documentation](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.cloudformation_include-readme.html)
+2. [cdk-from-cfn GitHub repository](https://github.com/cdklabs/cdk-from-cfn)
+3. [AWS CDK CfnResource API](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.CfnResource.html)
+4. [cfn-include README](../README.md)


### PR DESCRIPTION
## Summary

This PR adds comprehensive research and design documentation for Phase 4: AWS CDK Import/Eject Functionality.

## Contents

### Research
- AWS CDK CfnInclude module capabilities and limitations
- `cdk-from-cfn` tool analysis for CloudFormation → CDK conversion
- CDK construct levels (L1/L2/L3) and their relationship to CloudFormation

### EJECT Design (cfn-include → CDK)
- Two-phase approach: resolve cfn-include functions first, then convert to CDK
- Integration with `cdk-from-cfn` for code generation
- Output structure for complete CDK applications
- Handling of non-convertible features (Fn::Eval, dynamic includes)

### IMPORT Design (CDK → cfn-include)
- Pattern detection algorithms for repeated resources → Fn::Map
- Similar structure detection for Fn::Include extraction
- Optimization strategies

### CLI Design
```bash
cfn-include eject <template.yml> --output ./cdk-app --language typescript
cfn-include import <cdk-stack.json> --output ./cfn-template --optimize
```

### Challenges & Limitations
- Fn::Eval cannot be safely converted (contains arbitrary JS)
- Dynamic includes may not map cleanly
- CDK runtime values vs compile-time resolution
- L2 construct detection from raw CloudFormation

### Implementation Roadmap
- Phase 4.1: EJECT MVP (4-6 weeks)
- Phase 4.2: IMPORT MVP (6-8 weeks)
- Phase 4.3: Advanced Features (Future)

## Key Recommendations
1. Implement EJECT as a wrapper around `cdk-from-cfn` with preprocessing
2. IMPORT should focus on pattern detection for migration assistance rather than full conversion
3. Non-convertible features should warn users and output as comments