### PR TITLE
security: harden publish workflow against Mini Shai-Hulud (pin + egress)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,17 +12,32 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write  # Required for OIDC
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            uploads.github.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Publish to npm
         run: | # npm 11.15.1 for OIDC support
           npm install -g npm@11
-          npm ci
+          npm ci --ignore-scripts
           npm install
           npm publish --access public

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
+    'type-enum': [2, 'always', ['feat','fix','docs','style','refactor','perf','test','build','ci','chore','revert','security']],
     'body-max-line-length': [2, 'always', 200],
     'subject-case': [0, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
   },


### PR DESCRIPTION
## Summary

Part of the **Mini Shai-Hulud supply chain hardening campaign** — closing OIDC hijack vectors in GitHub Actions publish pipelines across the brickhouse-tech org and related repos.

### Changes

- Pin `actions/checkout` to SHA `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
- Pin `actions/setup-node` to SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0)
- Add `step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450` (v2.19.1) as first step with egress block allowlist
- Add `--ignore-scripts` to `npm ci` to block postinstall/preinstall script execution
- Add `contents: read` to job permissions (was missing — only `id-token: write` was set)

### Threat model

TeamPCP's Mini Shai-Hulud worm uses OIDC identity injection to hijack publish pipelines mid-workflow. Unpinned action refs allow SHA-swapping attacks; permissive egress allows exfiltration; missing `--ignore-scripts` allows dependency install-time code execution.

### Precedent

Same pattern already merged in:
- brickhouse-tech/.github#7
- brickhouse-tech/node-xml2js#6
- brickhouse-tech/angular.js#10
- brickhouse-tech/json-schema#4

## Test plan

- [ ] Workflow YAML is valid (no syntax errors)
- [ ] SHA pins match the tagged releases (v4.2.2, v6.4.0, harden-runner v2.19.1)
- [ ] `npm ci --ignore-scripts` does not break the publish for this package
- [ ] harden-runner egress allowlist covers all required endpoints for npm publish + OIDC